### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/michaelfay0059/27e5e022-5e55-41bf-87b9-7c3810020876/7026ca12-0d2d-421a-a117-0ee9c554dfcb/_apis/work/boardbadge/0dd1de97-f88b-4617-8598-dc46f8252977)](https://dev.azure.com/michaelfay0059/27e5e022-5e55-41bf-87b9-7c3810020876/_boards/board/t/7026ca12-0d2d-421a-a117-0ee9c554dfcb/Microsoft.RequirementCategory)
 # This is my github pages


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/michaelfay0059/27e5e022-5e55-41bf-87b9-7c3810020876/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.